### PR TITLE
end of line unification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,5 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all",
-  "endOfLine": "auto"
+  "trailingComma": "all"
 }


### PR DESCRIPTION
unify end of line configuration among git, editorconfig and prettier (which detects .editorconfig so no need to specify in .prettierrc) to all use lf
best to run `git reset --hard` (remember to first stash uncommited changes, if any) or something alike to update indexes on local repositories after applying this change